### PR TITLE
Renamed traversal functions, added search, changed ID structure

### DIFF
--- a/data.h
+++ b/data.h
@@ -189,9 +189,11 @@ void functions::traversedisplay(int i)
 
 int functions::searchmov(int n)
 {
+	//variable to know if Movie ID is found or not
 	int found = 0;
 	for(iter = MovieList.begin(); iter != MovieList.end(); iter++)
     {
+	//if the Node ID matches the search ID display movie info
         if (iter->id == n)
         {
         	cout<< "Video ID" << setw(13) << ": " << iter->id << endl;


### PR DESCRIPTION
Renamed traverse() to traversedisplay() 
-since it traverses AND displays the movies found within the linked list. 

Added search() function
-traverses the linked list to search a specific movie using its Movie ID

Refactored Movie IDs
-Movie IDs are now three digits, the first digit representing its genre (1 = Sci-Fi, 2 = Horror, 3 = Romance, 4 = Action, 5 = Comedy), the second & third digits representing the movie's order in the linked list (i.e. 101 is an Action Movie and the 1st movie in the linked list).